### PR TITLE
add mypy ignore line for `urllib.urlencode`

### DIFF
--- a/hypothesis.py
+++ b/hypothesis.py
@@ -6,7 +6,7 @@ import time
 import traceback
 
 try:
-    from urllib import urlencode
+    from urllib import urlencode  # type: ignore[attr-defined]
 except:
     from urllib.parse import urlencode
 


### PR DESCRIPTION
Hey, hope you don't mind it, this is the only mypy error for this file!
This import is python2 relevant only anyway, so ignoring seems like the easiest way to resolve it.