### PR TITLE
BugFix: accessing json object before response verification

### DIFF
--- a/hypothesis/hypothesis.py
+++ b/hypothesis/hypothesis.py
@@ -142,11 +142,10 @@ class Hypothesis:
         if self.token:
             headers["Authorization"] = "Bearer " + self.token
         r = requests.get(query_url, headers=headers)
-        obj = r.json()
         if r.ok:
-            return obj
+            return r.json()
         else:
-            raise Exception( "reason %s data %s" % (r.reason, obj) )
+            raise Exception( "reason %s" % (r.reason) )
 
     def get_annotation(self, id=None):
         h_url = "%s/annotations/%s" % (self.api_url, id)


### PR DESCRIPTION
The code is attempting to access the resulting JSON object before checking if the response from the server is a valid one.