### PR TITLE
fix: PY3.10 now warns when comparing literals with `is` keyword

### DIFF
--- a/hypothesis/hypothesis.py
+++ b/hypothesis/hypothesis.py
@@ -1,4 +1,4 @@
-﻿import json
+import json
 import re
 import requests
 from requests.adapters import HTTPAdapter
@@ -96,7 +96,7 @@ class Hypothesis:
             rows = obj["rows"]
             lr = len(rows)
             nresults += lr
-            if lr is 0:
+            if lr == 0:
                 return
 
             stop = None


### PR DESCRIPTION
The warning received is:
```
hypexport.git/src/hypexport/Hypothesis/hypothesis.py:99: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if lr is 0:
```